### PR TITLE
Increase code size limit from 24k to 256K

### DIFF
--- a/cmd/puppeth/genesis.go
+++ b/cmd/puppeth/genesis.go
@@ -417,7 +417,7 @@ func newParityChainSpec(network string, genesis *core.Genesis, bootnodes []strin
 	spec.Params.GasLimitBoundDivisor = (math2.HexOrDecimal64)(params.GasLimitBoundDivisor)
 	spec.Params.NetworkID = (hexutil.Uint64)(genesis.Config.ChainID.Uint64())
 	spec.Params.ChainID = (hexutil.Uint64)(genesis.Config.ChainID.Uint64())
-	spec.Params.MaxCodeSize = params.MaxCodeSize
+	spec.Params.MaxCodeSize = params.MaxCodeSizeHard
 	// geth has it set from zero
 	spec.Params.MaxCodeSizeTransition = 0
 

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -92,6 +92,7 @@ var (
 	SnapshotAccountPrefix = []byte("a") // SnapshotAccountPrefix + account hash -> account trie value
 	SnapshotStoragePrefix = []byte("o") // SnapshotStoragePrefix + account hash + storage hash -> storage trie value
 	CodePrefix            = []byte("c") // CodePrefix + code hash -> account code
+	CodeSizePrefix        = []byte("s") // CodePrefixSize
 
 	PreimagePrefix = []byte("secure-key-")      // PreimagePrefix + hash -> preimage
 	configPrefix   = []byte("ethereum-config-") // config prefix for the db
@@ -218,6 +219,10 @@ func preimageKey(hash common.Hash) []byte {
 // codeKey = CodePrefix + hash
 func codeKey(hash common.Hash) []byte {
 	return append(CodePrefix, hash.Bytes()...)
+}
+
+func codeSizeKey(hash common.Hash) []byte {
+	return append(CodeSizePrefix, hash.Bytes()...)
 }
 
 // IsCodeKey reports whether the given byte slice is the key of contract code,

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -194,6 +194,12 @@ func (db *cachingDB) ContractCodeSize(addrHash, codeHash common.Hash) (int, erro
 	if cached, ok := db.codeSizeCache.Get(codeHash); ok {
 		return cached.(int), nil
 	}
+
+	size := rawdb.ReadCodeSize(db.db.DiskDB(), codeHash)
+	if size != 0 {
+		return size, nil
+	}
+
 	code, err := db.ContractCode(addrHash, codeHash)
 	return len(code), err
 }

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -50,7 +50,7 @@ const (
 	// non-trivial consequences: larger transactions are significantly harder and
 	// more expensive to propagate; larger transactions also take more resources
 	// to validate whether they fit into the pool or not.
-	txMaxSize = 4 * txSlotSize // 128KB
+	txMaxSize = 16 * txSlotSize // 512KB (tentative)
 )
 
 var (

--- a/core/vm/errors.go
+++ b/core/vm/errors.go
@@ -36,6 +36,7 @@ var (
 	ErrGasUintOverflow          = errors.New("gas uint64 overflow")
 	ErrInvalidCode              = errors.New("invalid code: must not begin with 0xef")
 	ErrNonceUintOverflow        = errors.New("nonce uint64 overflow")
+	ErrCodeInsufficientStake    = errors.New("insufficient staking for code")
 
 	// errStopToken is an internal token indicating interpreter loop termination,
 	// never returned to outside callers.

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -329,7 +329,7 @@ func addGasExtraCodeSize(evm *EVM, address common.Address, gas uint64) (uint64, 
 	// codeSize := address.
 	codeSize := evm.StateDB.GetCodeSize(address)
 	if codeSize <= params.MaxCodeSizeSoft {
-		return 0, false // already accounted by constant gas
+		return gas, false // already accounted by constant gas
 	}
 
 	extraGas := (uint64(codeSize) - 1) / params.ExtcodeCopyChunkSize * params.CallGasEIP150

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -325,6 +325,17 @@ func gasExpEIP158(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memor
 	return gas, nil
 }
 
+func addGasExtraCodeSize(evm *EVM, address common.Address, gas uint64) (uint64, bool) {
+	// codeSize := address.
+	codeSize := evm.StateDB.GetCodeSize(address)
+	if codeSize <= params.MaxCodeSizeSoft {
+		return 0, false // already accounted by constant gas
+	}
+
+	extraGas := (uint64(codeSize) - 1) / params.ExtcodeCopyChunkSize * params.CallGasEIP150
+	return math.SafeAdd(gas, extraGas)
+}
+
 func gasCall(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
 	var (
 		gas            uint64
@@ -357,6 +368,10 @@ func gasCall(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize
 	if gas, overflow = math.SafeAdd(gas, evm.callGasTemp); overflow {
 		return 0, ErrGasUintOverflow
 	}
+
+	if gas, overflow = addGasExtraCodeSize(evm, address, gas); overflow {
+		return 0, ErrGasUintOverflow
+	}
 	return gas, nil
 }
 
@@ -368,6 +383,7 @@ func gasCallCode(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memory
 	var (
 		gas      uint64
 		overflow bool
+		address  = common.Address(stack.Back(1).Bytes20())
 	)
 	if stack.Back(2).Sign() != 0 {
 		gas += params.CallValueTransferGas
@@ -382,10 +398,14 @@ func gasCallCode(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memory
 	if gas, overflow = math.SafeAdd(gas, evm.callGasTemp); overflow {
 		return 0, ErrGasUintOverflow
 	}
+	if gas, overflow = addGasExtraCodeSize(evm, address, gas); overflow {
+		return 0, ErrGasUintOverflow
+	}
 	return gas, nil
 }
 
 func gasDelegateCall(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
+	address := common.Address(stack.Back(1).Bytes20())
 	gas, err := memoryGasCost(mem, memorySize)
 	if err != nil {
 		return 0, err
@@ -398,10 +418,14 @@ func gasDelegateCall(evm *EVM, contract *Contract, stack *Stack, mem *Memory, me
 	if gas, overflow = math.SafeAdd(gas, evm.callGasTemp); overflow {
 		return 0, ErrGasUintOverflow
 	}
+	if gas, overflow = addGasExtraCodeSize(evm, address, gas); overflow {
+		return 0, ErrGasUintOverflow
+	}
 	return gas, nil
 }
 
 func gasStaticCall(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
+	address := common.Address(stack.Back(1).Bytes20())
 	gas, err := memoryGasCost(mem, memorySize)
 	if err != nil {
 		return 0, err
@@ -412,6 +436,9 @@ func gasStaticCall(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memo
 	}
 	var overflow bool
 	if gas, overflow = math.SafeAdd(gas, evm.callGasTemp); overflow {
+		return 0, ErrGasUintOverflow
+	}
+	if gas, overflow = addGasExtraCodeSize(evm, address, gas); overflow {
 		return 0, ErrGasUintOverflow
 	}
 	return gas, nil

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -326,10 +326,9 @@ func gasExpEIP158(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memor
 }
 
 func addGasExtraCodeSize(evm *EVM, address common.Address, gas uint64) (uint64, bool) {
-	// codeSize := address.
 	codeSize := evm.StateDB.GetCodeSize(address)
 	if codeSize <= params.MaxCodeSizeSoft {
-		return gas, false // already accounted by constant gas
+		return gas, false
 	}
 
 	extraGas := (uint64(codeSize) - 1) / params.ExtcodeCopyChunkSize * params.CallGasEIP150

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -383,6 +383,13 @@ func opExtCodeCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext)
 		uint64CodeOffset = 0xffffffffffffffff
 	}
 	addr := common.Address(a.Bytes20())
+	codeSize := interpreter.evm.StateDB.GetCodeSize(addr)
+	if codeSize > params.MaxCodeSizeSoft {
+		extraGas := (uint64(codeSize - 1)) / params.ExtcodeCopyChunkSize * params.ExtcodeCopyBasePerChunk
+		if !scope.Contract.UseGas(extraGas) {
+			return nil, ErrOutOfGas
+		}
+	}
 	codeCopy := getData(interpreter.evm.StateDB.GetCode(addr), uint64CodeOffset, length.Uint64())
 	scope.Memory.Set(memOffset.Uint64(), length.Uint64(), codeCopy)
 

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -113,6 +113,10 @@ const (
 	// static portion of the gas. It was changed during EIP 150 (Tangerine)
 	ExtcodeCopyBaseFrontier uint64 = 20
 	ExtcodeCopyBaseEIP150   uint64 = 700
+	ExtcodeCopyBasePerChunk uint64 = 700
+	ExtcodeCopyChunkSize    uint64 = MaxCodeSizeSoft
+
+	CodeStakingPerChunk uint64 = 1000000000000000000 // 1 token per 24k (reclaimable)
 
 	// CreateBySelfdestructGas is used when the refunded account is one that does
 	// not exist. This logic is similar to call.
@@ -123,7 +127,8 @@ const (
 	ElasticityMultiplier     = 2          // Bounds the maximum gas limit an EIP-1559 block may have.
 	InitialBaseFee           = 1000000000 // Initial base fee for EIP-1559 blocks.
 
-	MaxCodeSize = 24576 // Maximum bytecode to permit for a contract
+	MaxCodeSizeSoft = 24576 // Maximum bytecode to permit for a contract
+	MaxCodeSizeHard = 1024 * 1024
 
 	// Precompiled contract gas prices
 

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -127,8 +127,8 @@ const (
 	ElasticityMultiplier     = 2          // Bounds the maximum gas limit an EIP-1559 block may have.
 	InitialBaseFee           = 1000000000 // Initial base fee for EIP-1559 blocks.
 
-	MaxCodeSizeSoft = 24576 // Maximum bytecode to permit for a contract
-	MaxCodeSizeHard = 1024 * 1024
+	MaxCodeSizeSoft = 24576      // Maximum bytecode to permit for a contract without staking
+	MaxCodeSizeHard = 512 * 1024 // Maximum bytecode to permit for a contract with staking (hardlimit)
 
 	// Precompiled contract gas prices
 

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -116,7 +116,7 @@ const (
 	ExtcodeCopyBasePerChunk uint64 = 700
 	ExtcodeCopyChunkSize    uint64 = MaxCodeSizeSoft
 
-	CodeStakingPerChunk uint64 = 1000000000000000000 // 1 token per 24k (reclaimable)
+	CodeStakingPerChunk uint64 = 1000000000000000000 // 1 token per 24k (reclaimable upon suicide)
 
 	// CreateBySelfdestructGas is used when the refunded account is one that does
 	// not exist. This logic is similar to call.


### PR DESCRIPTION
A couple of main changes:
- Add code size key in rawdb so that  gas related to reading code size is the same as before
- For writing a code size > 24k, each extra 24k data will require 1 token for staking
- For reading a code size > 24k, each extra 24k code size (chunk) e of the contract will require 700 * # of chunks.  This applies to both EXTCODECOPY (contract code copy) and contract call (CALL, DELEGATECALL, CODECALL, STATICCALL).