### PR TITLE
use gov to check validators

### DIFF
--- a/consensus/tendermint/adapter/store.go
+++ b/consensus/tendermint/adapter/store.go
@@ -7,7 +7,6 @@ import (
 	pbft "github.com/QuarkChain/go-minimal-pbft/consensus"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
-	"github.com/ethereum/go-ethereum/consensus/tendermint/gov"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
@@ -15,17 +14,15 @@ import (
 
 type Store struct {
 	chain            *core.BlockChain
-	governance       *gov.Governance
 	verifyHeaderFunc func(chain consensus.ChainHeaderReader, header *types.Header, seal bool) error
 	makeBlock        func(parentHash common.Hash, coinbase common.Address, timestamp uint64) (block *types.FullBlock)
 }
 
 func NewStore(
 	chain *core.BlockChain,
-	governance *gov.Governance,
 	verifyHeaderFunc func(chain consensus.ChainHeaderReader, header *types.Header, seal bool) error,
 	makeBlock func(parentHash common.Hash, coinbase common.Address, timestamp uint64) (block *types.FullBlock)) *Store {
-	return &Store{chain: chain, governance: governance, verifyHeaderFunc: verifyHeaderFunc, makeBlock: makeBlock}
+	return &Store{chain: chain, verifyHeaderFunc: verifyHeaderFunc, makeBlock: makeBlock}
 }
 
 func (s *Store) Base() uint64 {

--- a/consensus/tendermint/gov/gov.go
+++ b/consensus/tendermint/gov/gov.go
@@ -2,28 +2,28 @@ package gov
 
 import (
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/consensus"
 )
 
 type Governance struct {
 	epoch uint64
-	chain *core.BlockChain
+	chain consensus.ChainHeaderReader
 }
 
-func New(epoch uint64, chain *core.BlockChain) *Governance {
+func New(epoch uint64, chain consensus.ChainHeaderReader) *Governance {
 	return &Governance{epoch: epoch, chain: chain}
 }
 
 // EpochValidators returns the current epoch validators that height belongs to
 func (g *Governance) EpochValidators(height uint64) []common.Address {
-	// TODO get real validators by calling contract
+	// TODO: get real validators by calling contract
 	header := g.chain.GetHeaderByNumber(0)
 	return header.NextValidators
 }
 
 func (g *Governance) NextValidators(height uint64) []common.Address {
 	if height%g.epoch != 0 {
-		return nil
+		return []common.Address{}
 	}
 
 	switch {
@@ -31,15 +31,43 @@ func (g *Governance) NextValidators(height uint64) []common.Address {
 		header := g.chain.GetHeaderByNumber(0)
 		return header.NextValidators
 	default:
-		// TODO get real validators by calling contract
-		header := g.chain.GetHeaderByNumber(height - g.epoch)
+		// TODO: get real validators by calling contract, currently use genesis
+		header := g.chain.GetHeaderByNumber(0)
 		return header.NextValidators
 	}
 }
 
+func CompareValidators(lhs, rhs []common.Address) bool {
+	if len(lhs) != len(rhs) {
+		return false
+	}
+
+	for i := 0; i < len(lhs); i++ {
+		if lhs[i] != rhs[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func CompareValidatorPowers(lhs, rhs []uint64) bool {
+	if len(lhs) != len(rhs) {
+		return false
+	}
+
+	for i := 0; i < len(lhs); i++ {
+		if lhs[i] != rhs[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
 func (g *Governance) NextValidatorPowers(height uint64) []uint64 {
 	if height%g.epoch != 0 {
-		return nil
+		return []uint64{}
 	}
 
 	switch {
@@ -48,7 +76,7 @@ func (g *Governance) NextValidatorPowers(height uint64) []uint64 {
 		return header.NextValidatorPowers
 	default:
 		// TODO get real validators by calling contract
-		header := g.chain.GetHeaderByNumber(height - g.epoch)
+		header := g.chain.GetHeaderByNumber(0)
 		return header.NextValidatorPowers
 	}
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -32,7 +32,6 @@ import (
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/beacon"
 	"github.com/ethereum/go-ethereum/consensus/clique"
-	"github.com/ethereum/go-ethereum/consensus/tendermint"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/bloombits"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -200,9 +199,6 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	eth.blockchain, err = core.NewBlockChain(chainDb, cacheConfig, chainConfig, eth.engine, vmConfig, eth.shouldPreserve, &config.TxLookupLimit)
 	if err != nil {
 		return nil, err
-	}
-	if tm, ok := eth.engine.(*tendermint.Tendermint); ok {
-		tm.SetBlockChain(eth.blockchain)
 	}
 	// Rewind the chain in case of an incompatible config upgrade.
 	if compat, ok := genesisErr.(*params.ConfigCompatError); ok {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -458,7 +458,7 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 		case <-w.startCh:
 			clearPending(w.chain.CurrentBlock().NumberU64())
 			if isTm {
-				err := tm.Init(w.makeBlock)
+				err := tm.Init(w.chain, w.makeBlock)
 				if err != nil {
 					log.Crit("tm.Init", "err", err)
 				}


### PR DESCRIPTION
- use governance module to check next validators and powers
- do not use SetBlockchain() as the VerifyHeader() can be called before SetBlockchain(), resulting in panic().  Instead, use the ChainHeadReader parameter in VerifyHeader().  In the future, once we have implemented PoS, we may add a method in ChainHeadReader to read the validators/powers either internally (local contracts) or externally (from Ethereum contract).