### PR TITLE
integrate eth wallet for chamber validator

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -291,6 +291,9 @@ func prepare(ctx *cli.Context) {
 	case ctx.GlobalIsSet(utils.Web3QTestnetFlag.Name):
 		log.Info("Starting Geth in Web3Q dev mode...")
 
+	case ctx.GlobalIsSet(utils.Web3QGalileoFlag.Name):
+		log.Info("Starting Geth in Web3Q Galileo testnet...")
+
 	case !ctx.GlobalIsSet(utils.NetworkIdFlag.Name):
 		log.Info("Starting Geth on Ethereum mainnet...")
 	}

--- a/consensus/tendermint/priv_validator.go
+++ b/consensus/tendermint/priv_validator.go
@@ -1,0 +1,80 @@
+package tendermint
+
+import (
+	"context"
+	"sync"
+
+	pbft "github.com/QuarkChain/go-minimal-pbft/consensus"
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+type EthPrivValidator struct {
+	signer common.Address // Ethereum address of the signing key
+	signFn SignerFn       // Signer function to authorize hashes with
+	lock   sync.RWMutex   // Protects the signer fields
+}
+
+type EthPubKey struct {
+	signer common.Address
+}
+
+func (pubkey *EthPubKey) Type() string {
+	return "ETH_PUBKEY"
+}
+
+func (pubkey *EthPubKey) Address() common.Address {
+	return pubkey.signer
+}
+
+func (pubkey *EthPubKey) VerifySignature(msg []byte, sig []byte) bool {
+	pub, err := crypto.Ecrecover(msg, sig)
+	if err != nil {
+		return false
+	}
+
+	if len(pub) == 0 || pub[0] != 4 {
+		return false
+	}
+
+	var signer common.Address
+	copy(signer[:], crypto.Keccak256(pub[1:])[12:])
+	return signer == pubkey.signer
+}
+
+func NewEthPrivValidator(signer common.Address, signFn SignerFn) pbft.PrivValidator {
+	return &EthPrivValidator{signer: signer, signFn: signFn}
+}
+
+func (pv *EthPrivValidator) Address() common.Address {
+	return pv.signer
+}
+
+func (pv *EthPrivValidator) GetPubKey(context.Context) (pbft.PubKey, error) {
+	return &EthPubKey{signer: pv.signer}, nil
+}
+
+func (pv *EthPrivValidator) SignVote(ctx context.Context, chainId string, vote *pbft.Vote) error {
+	pv.lock.Lock()
+	defer pv.lock.Unlock()
+
+	vote.TimestampMs = uint64(pbft.CanonicalNowMs())
+	b := vote.VoteSignBytes(chainId)
+
+	sign, err := pv.signFn(accounts.Account{Address: pv.signer}, accounts.MimetypeClique, b)
+	vote.Signature = sign
+
+	return err
+}
+
+func (pv *EthPrivValidator) SignProposal(ctx context.Context, chainID string, proposal *pbft.Proposal) error {
+	pv.lock.Lock()
+	defer pv.lock.Unlock()
+	// TODO: sanity check
+	b := proposal.ProposalSignBytes(chainID)
+
+	sign, err := pv.signFn(accounts.Account{Address: pv.signer}, accounts.MimetypeClique, b)
+	proposal.Signature = sign
+	return err
+}

--- a/consensus/tendermint/priv_validator.go
+++ b/consensus/tendermint/priv_validator.go
@@ -2,7 +2,6 @@ package tendermint
 
 import (
 	"context"
-	"sync"
 
 	pbft "github.com/QuarkChain/go-minimal-pbft/consensus"
 	"github.com/ethereum/go-ethereum/accounts"
@@ -13,7 +12,6 @@ import (
 type EthPrivValidator struct {
 	signer common.Address // Ethereum address of the signing key
 	signFn SignerFn       // Signer function to authorize hashes with
-	lock   sync.RWMutex   // Protects the signer fields
 }
 
 type EthPubKey struct {
@@ -56,9 +54,6 @@ func (pv *EthPrivValidator) GetPubKey(context.Context) (pbft.PubKey, error) {
 }
 
 func (pv *EthPrivValidator) SignVote(ctx context.Context, chainId string, vote *pbft.Vote) error {
-	pv.lock.Lock()
-	defer pv.lock.Unlock()
-
 	vote.TimestampMs = uint64(pbft.CanonicalNowMs())
 	b := vote.VoteSignBytes(chainId)
 
@@ -69,8 +64,6 @@ func (pv *EthPrivValidator) SignVote(ctx context.Context, chainId string, vote *
 }
 
 func (pv *EthPrivValidator) SignProposal(ctx context.Context, chainID string, proposal *pbft.Proposal) error {
-	pv.lock.Lock()
-	defer pv.lock.Unlock()
 	// TODO: sanity check
 	b := proposal.ProposalSignBytes(chainID)
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/Azure/azure-storage-blob-go v0.7.0
-	github.com/QuarkChain/go-minimal-pbft v0.0.0-20220307211413-49a75ab4c3f2 // indirect
+	github.com/QuarkChain/go-minimal-pbft v0.0.0-20220307211413-49a75ab4c3f2
 	github.com/VictoriaMetrics/fastcache v1.6.0
 	github.com/aws/aws-sdk-go-v2 v1.2.0
 	github.com/aws/aws-sdk-go-v2/config v1.1.1

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -427,7 +427,7 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 	defer timer.Stop()
 	<-timer.C // discard the initial tick
 
-	tm, isTm := w.engine.(*tendermint.Tendermint)
+	_, isTm := w.engine.(*tendermint.Tendermint)
 	// commit aborts in-flight transaction execution with given signal and resubmits a new one.
 	commit := func(noempty bool, s int32) {
 		if interrupt != nil {
@@ -457,11 +457,8 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 		select {
 		case <-w.startCh:
 			clearPending(w.chain.CurrentBlock().NumberU64())
+
 			if isTm {
-				err := tm.Init(w.chain, w.makeBlock)
-				if err != nil {
-					log.Crit("tm.Init", "err", err)
-				}
 				continue
 			}
 

--- a/params/bootnodes.go
+++ b/params/bootnodes.go
@@ -82,7 +82,9 @@ var Web3QTestnetBootnodes = []string{
 }
 
 // TODO: to update
-var Web3QGalileoBootnodes = []string{}
+var Web3QGalileoBootnodes = []string{
+	"enode://1b9032f19ae39390e84718071ac8d560f5a11e1b8e02de4a40654a9d2950ae77b34a2ca90854413dfe5973c0040d0928a5cf27a46cd8cc1c6a8fbc1fb7d2825f@127.0.0.1:30303",
+}
 
 var Web3QMainnetBootnodes = []string{
 	"enode://0c2e9b39c4f8655d6cdd3dd3a57bee4fb1c20a3c844507b36bd806d7219048e3df6b7bc3dcc0a1830b59c7d25f983572c11a8ab8469e21a8d937f4ba84d98288@143.244.163.228:30303",

--- a/params/chamber_config.go
+++ b/params/chamber_config.go
@@ -1,0 +1,86 @@
+package params
+
+import "time"
+
+// ConsensusConfig defines the configuration for the Tendermint consensus service,
+// including timeouts and details about the WAL and the block structure.
+type ConsensusConfig struct {
+	RootDir string `mapstructure:"home"`
+	WalPath string `mapstructure:"wal-file"`
+	WalFile string // overrides WalPath if set
+
+	// TODO: remove timeout configs, these should be global not local
+	// How long we wait for a proposal block before prevoting nil
+	TimeoutPropose time.Duration `mapstructure:"timeout-propose"`
+	// How much timeout-propose increases with each round
+	TimeoutProposeDelta time.Duration `mapstructure:"timeout-propose-delta"`
+	// How long we wait after receiving +2/3 prevotes for “anything” (ie. not a single block or nil)
+	TimeoutPrevote time.Duration `mapstructure:"timeout-prevote"`
+	// How much the timeout-prevote increases with each round
+	TimeoutPrevoteDelta time.Duration `mapstructure:"timeout-prevote-delta"`
+	// How long we wait after receiving +2/3 precommits for “anything” (ie. not a single block or nil)
+	TimeoutPrecommit time.Duration `mapstructure:"timeout-precommit"`
+	// How much the timeout-precommit increases with each round
+	TimeoutPrecommitDelta time.Duration `mapstructure:"timeout-precommit-delta"`
+	// How long we wait after committing a block, before starting on the new
+	// height (this gives us a chance to receive some more precommits, even
+	// though we already have +2/3).
+	TimeoutCommit time.Duration `mapstructure:"timeout-commit"`
+
+	// Make progress as soon as we have all the precommits (as if TimeoutCommit = 0)
+	SkipTimeoutCommit bool `mapstructure:"skip-timeout-commit"`
+
+	// Reactor sleep duration parameters
+	PeerGossipSleepDuration     time.Duration `mapstructure:"peer-gossip-sleep-duration"`
+	PeerQueryMaj23SleepDuration time.Duration `mapstructure:"peer-query-maj23-sleep-duration"`
+
+	ConsensusSyncRequestDuration time.Duration
+
+	DoubleSignCheckHeight uint64 `mapstructure:"double-sign-check-height"`
+}
+
+func NewDefaultConsesusConfig() *ConsensusConfig {
+	// Config from tendermint except TimeoutCommit is 5s (original 1s)
+	return &ConsensusConfig{
+		// WalPath:                     filepath.Join(defaultDataDir, "cs.wal", "wal"),
+		TimeoutPropose:               3000 * time.Millisecond,
+		TimeoutProposeDelta:          500 * time.Millisecond,
+		TimeoutPrevote:               1000 * time.Millisecond,
+		TimeoutPrevoteDelta:          500 * time.Millisecond,
+		TimeoutPrecommit:             1000 * time.Millisecond,
+		TimeoutPrecommitDelta:        500 * time.Millisecond,
+		TimeoutCommit:                5000 * time.Millisecond,
+		SkipTimeoutCommit:            false,
+		PeerGossipSleepDuration:      100 * time.Millisecond,
+		PeerQueryMaj23SleepDuration:  2000 * time.Millisecond,
+		DoubleSignCheckHeight:        uint64(0),
+		ConsensusSyncRequestDuration: 500 * time.Millisecond,
+	}
+}
+
+// Propose returns the amount of time to wait for a proposal
+func (cfg *ConsensusConfig) Propose(round int32) time.Duration {
+	return time.Duration(
+		cfg.TimeoutPropose.Nanoseconds()+cfg.TimeoutProposeDelta.Nanoseconds()*int64(round),
+	) * time.Nanosecond
+}
+
+// Prevote returns the amount of time to wait for straggler votes after receiving any +2/3 prevotes
+func (cfg *ConsensusConfig) Prevote(round int32) time.Duration {
+	return time.Duration(
+		cfg.TimeoutPrevote.Nanoseconds()+cfg.TimeoutPrevoteDelta.Nanoseconds()*int64(round),
+	) * time.Nanosecond
+}
+
+// Precommit returns the amount of time to wait for straggler votes after receiving any +2/3 precommits
+func (cfg *ConsensusConfig) Precommit(round int32) time.Duration {
+	return time.Duration(
+		cfg.TimeoutPrecommit.Nanoseconds()+cfg.TimeoutPrecommitDelta.Nanoseconds()*int64(round),
+	) * time.Nanosecond
+}
+
+// Commit returns the amount of time to wait for straggler votes after receiving +2/3 precommits
+// for a single block (ie. a commit).
+func (cfg *ConsensusConfig) Commit(t time.Time) time.Time {
+	return t.Add(cfg.TimeoutCommit)
+}

--- a/params/config.go
+++ b/params/config.go
@@ -300,7 +300,6 @@ var (
 			ProposerRepetition: 8,
 			P2pBootstrap:       "/ip4/127.0.0.1/udp/33333/quic/p2p/12D3KooWRqZRJf6gYeLgeUnNCnKeRb29KiEVQcvRWk2tet9Q3Hmy",
 			NodeKeyPath:        "/Users/qizhou/.ssh/node_galileo.key",
-			ValKeyPath:         "/Users/qizhou/.ssh/val_galileo.key",
 			ConsensusConfig: ConsensusConfig{
 				// WalPath:                     filepath.Join(defaultDataDir, "cs.wal", "wal"),
 				TimeoutPropose:               3000 * time.Millisecond,
@@ -464,7 +463,6 @@ type CliqueConfig struct {
 
 type TendermintConfig struct {
 	Epoch              uint64 `json:"epoch"` // Epoch lengh to vote new validator
-	ValKeyPath         string
 	NodeKeyPath        string
 	P2pPort            uint
 	NetworkID          string


### PR DESCRIPTION
- use Ethereum wallet system to sign and verify validator (and remove existing valKey)
- initialize TM when starting mining.  This prevents early and double initialization since miner/worker will immediately send msg to startCh when created.
- remove empty API service (replaced by empty array).  The original code blocks the initialization steps of the node and results in unsafe shutdown. 
- add a bootnode (will be changed) so that P2P server can start (instead of being blocked)