### PR TITLE
check header.LastCommitHash

### DIFF
--- a/consensus/tendermint/adapter/store.go
+++ b/consensus/tendermint/adapter/store.go
@@ -117,6 +117,9 @@ func (s *Store) ValidateBlock(state pbft.ChainState, block *types.FullBlock) (er
 			state.ChainID, state.LastBlockID, block.NumberU64()-1, block.LastCommit); err != nil {
 			return err
 		}
+		if block.Block.Header().LastCommitHash != block.LastCommit.Hash() {
+			return errors.New("header.LastCommitHash != LastCommit.Hash()")
+		}
 	}
 
 	// Validate block Time with LastCommit


### PR DESCRIPTION
`header.LastCommitHash` is not checked in `tm.VerifyHeader`, we should check it here.