### PR TITLE
disable bootnode in stress test

### DIFF
--- a/consensus/tendermint/tendermint.go
+++ b/consensus/tendermint/tendermint.go
@@ -116,6 +116,7 @@ func (c *Tendermint) Authorize(signer common.Address, signFn SignerFn) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
+	log.Info("Authorize", "signer", signer)
 	c.privVal = NewEthPrivValidator(signer, signFn)
 }
 


### PR DESCRIPTION
When I run stress test locally, I saw many errors like this:

```
INFO [03-15|11:39:10.127] failed attempting to add vote            err="vote.ValidatorAddress (90A7BFF0B4B11F365367D4C9FE084223C850B229) does not match address (3F1A62D9610DF6AFF902F71A53523F8741CA2F34) for vote.ValidatorIndex (1)\nEnsure the genesis file is correct across all validators: invalid validator address"
```

This pr fixes it.