### PR TITLE
processing committed block validates commit only

### DIFF
--- a/consensus/tendermint/adapter/store.go
+++ b/consensus/tendermint/adapter/store.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
 	pbft "github.com/ethereum/go-ethereum/consensus/tendermint/consensus"
@@ -92,15 +93,11 @@ func (s *Store) SaveBlock(block *types.FullBlock, commit *types.Commit) {
 	s.mux.Post(core.NewMinedBlockEvent{Block: block.WithCommit(commit).Block})
 }
 
-func (s *Store) VerifyBlock(state pbft.ChainState, block *types.FullBlock) (err error) {
-	return s.verifyHeaderFunc(s.chain, block.Header(), true)
-}
-
 // Validate a block without Commit and with LastCommit.
-func (s *Store) ValidateBlock(state pbft.ChainState, block *types.FullBlock) (err error) {
+func (s *Store) ValidateBlock(state pbft.ChainState, block *types.FullBlock, committed bool) (err error) {
 	header := block.Header()
-	err = s.verifyHeaderFunc(s.chain, header, false)
-	if err != nil {
+	err = s.verifyHeaderFunc(s.chain, header, committed)
+	if err != nil || committed {
 		return
 	}
 

--- a/consensus/tendermint/adapter/store.go
+++ b/consensus/tendermint/adapter/store.go
@@ -92,6 +92,10 @@ func (s *Store) SaveBlock(block *types.FullBlock, commit *types.Commit) {
 	s.mux.Post(core.NewMinedBlockEvent{Block: block.WithCommit(commit).Block})
 }
 
+func (s *Store) VerifyBlock(state pbft.ChainState, block *types.FullBlock) (err error) {
+	return s.verifyHeaderFunc(s.chain, block.Header(), true)
+}
+
 // Validate a block without Commit and with LastCommit.
 func (s *Store) ValidateBlock(state pbft.ChainState, block *types.FullBlock) (err error) {
 	header := block.Header()

--- a/consensus/tendermint/consensus/default_block_executor.go
+++ b/consensus/tendermint/consensus/default_block_executor.go
@@ -18,6 +18,11 @@ func NewDefaultBlockExecutor(db *leveldb.DB) BlockExecutor {
 	return &DefaultBlockExecutor{}
 }
 
+func (be *DefaultBlockExecutor) VerifyBlock(state ChainState, b *FullBlock) error {
+	// TODO: only need to check commit
+	return validateBlock(state, b)
+}
+
 func (be *DefaultBlockExecutor) ValidateBlock(state ChainState, b *FullBlock) error {
 	return validateBlock(state, b)
 }

--- a/consensus/tendermint/consensus/default_block_executor.go
+++ b/consensus/tendermint/consensus/default_block_executor.go
@@ -18,16 +18,12 @@ func NewDefaultBlockExecutor(db *leveldb.DB) BlockExecutor {
 	return &DefaultBlockExecutor{}
 }
 
-func (be *DefaultBlockExecutor) VerifyBlock(state ChainState, b *FullBlock) error {
-	// TODO: only need to check commit
-	return validateBlock(state, b)
+func (be *DefaultBlockExecutor) ValidateBlock(state ChainState, b *FullBlock, committed bool) error {
+	return validateBlock(state, b, committed)
 }
 
-func (be *DefaultBlockExecutor) ValidateBlock(state ChainState, b *FullBlock) error {
-	return validateBlock(state, b)
-}
-
-func validateBlock(state ChainState, block *FullBlock) error {
+func validateBlock(state ChainState, block *FullBlock, committed bool) error {
+	// TODO: verify signatures only when committed=true
 
 	// Validate basic info.
 

--- a/consensus/tendermint/p2p/block_sync.go
+++ b/consensus/tendermint/p2p/block_sync.go
@@ -78,7 +78,7 @@ func (bs *BlockSync) sync(ctx context.Context) error {
 				return err
 			}
 
-			if err := bs.executor.ValidateBlock(bs.chainState, &vb); err != nil {
+			if err := bs.executor.ValidateBlock(bs.chainState, &vb, true); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
When a peer sends a committed block to local, the block already contains sufficient signature to verify the validity.  As a result, we do need to touch the LastCommit part to verify the block.