### PR TITLE
fix relayer bug

### DIFF
--- a/cmd/w3qrelayer/relayer.go
+++ b/cmd/w3qrelayer/relayer.go
@@ -201,7 +201,8 @@ func runRelay(cmd *cobra.Command, args []string) {
 
 			err = relayer.SubmitHeaderToContract(header)
 			if err == nil {
-				time.Sleep((comfirmCount + 5) * blockTime * time.Second) // wait for the tx been confirmed
+				log.Info("wait for tx been confirmed", "sleep time (seconds)", (comfirmCount+5)*blockTime)
+				time.Sleep((comfirmCount + 5) * blockTime * time.Second)
 				continue
 			}
 			log.Error("SubmitHeaderToContract failed", "err", err.Error())

--- a/cmd/w3qrelayer/relayer.go
+++ b/cmd/w3qrelayer/relayer.go
@@ -30,7 +30,8 @@ const (
 	SubmitHeaderFunc       = "submitHead"
 	GetNextEpochHeightFunc = "getNextEpochHeight"
 	gas                    = uint64(1000000) // uint64(math.MaxUint64 / 2)
-	comfirmCount           = 50              // 10 * 60 / 12
+	comfirmCount           = 40              // 10 * 60 seconds / 15 seconds
+	blockTime              = 15              // seconds
 )
 
 var (
@@ -200,7 +201,7 @@ func runRelay(cmd *cobra.Command, args []string) {
 
 			err = relayer.SubmitHeaderToContract(header)
 			if err == nil {
-				time.Sleep(1 * time.Minute)
+				time.Sleep((comfirmCount + 5) * blockTime * time.Second) // wait for the tx been confirmed
 				continue
 			}
 			log.Error("SubmitHeaderToContract failed", "err", err.Error())

--- a/params/config.go
+++ b/params/config.go
@@ -279,7 +279,7 @@ var (
 		LondonBlock:         big.NewInt(0),
 		ArrowGlacierBlock:   nil,
 		Tendermint: &TendermintConfig{
-			Epoch:                  10000,
+			Epoch:                  1000,
 			ValidatorContract:      "",
 			ContractChainID:        0,
 			ValidatorChangeEpochId: 0,


### PR DESCRIPTION
after relayer.SubmitHeaderToContract(header) submit success, we need to wait for it to be packed to block, and also need to wait for the block to be confirmed. otherwise, relayer.GetNextEpochHeight(curNumber - comfirmCount) will still get Expired next epoch height and cause the relayer to submit the expired header multi times and failed. So we need to wait until the block with TX has been confirmed.