### PR TITLE
use kvSizeBits/kvEntrieBits instead of kvSize/kvEntries to init shard manager

### DIFF
--- a/eth/protocols/sstorage/sync.go
+++ b/eth/protocols/sstorage/sync.go
@@ -45,7 +45,7 @@ const (
 
 	maxConcurrency = 16
 
-	minSubTaskSize = 512
+	minSubTaskSize = 16
 )
 
 // ErrCancelled is returned from sstorage syncing if the operation was prematurely
@@ -172,7 +172,7 @@ type kvHealTask struct {
 func (h *kvHealTask) hasIndexInRange(first, last uint64) (bool, uint64) {
 	min, exist := last, false
 	for idx, _ := range h.Indexes {
-		if idx <= last && idx >= first {
+		if idx < last && idx >= first {
 			exist = true
 			if min > idx {
 				min = idx
@@ -690,7 +690,7 @@ func (s *Syncer) assignKVRangeTasks(success chan *kvRangeResponse, fail chan *kv
 				contract: task.Contract,
 				shardId:  task.ShardId,
 				origin:   subTask.next,
-				limit:    subTask.Last,
+				limit:    subTask.Last - 1,
 				time:     time.Now(),
 				deliver:  success,
 				revert:   fail,
@@ -981,7 +981,7 @@ func (s *Syncer) processKVRangeResponse(res *kvRangeResponse) {
 			res.task.kvTask.HealTask.Indexes[n] = 0
 		}
 	}
-	if max == res.task.Last {
+	if max == res.task.Last-1 {
 		res.task.done = true
 	} else {
 		res.task.next = max + 1
@@ -1079,7 +1079,7 @@ func (s *Syncer) OnKVs(peer SyncPeer, id uint64, providerAddr common.Address, kv
 	// get id range and check range
 	sm := sstorage.ContractToShardManager[req.contract]
 	if sm == nil {
-		logger.Debug("Peer rejected kv request")
+		logger.Debug("Peer rejected kv request", "len", len(req.task.kvTask.HealTask.Indexes))
 		req.task.kvTask.statelessPeers[peer.ID()] = struct{}{}
 		s.lock.Unlock()
 
@@ -1174,7 +1174,7 @@ func (s *Syncer) OnKVRange(peer SyncPeer, id uint64, providerAddr common.Address
 	// get id range and check range
 	sm := sstorage.ContractToShardManager[req.contract]
 	if sm == nil {
-		logger.Debug("Peer rejected kv request")
+		logger.Debug("Peer rejected kv request", "origin", req.origin, "limit", req.limit)
 		req.task.kvTask.statelessPeers[peer.ID()] = struct{}{}
 		s.lock.Unlock()
 

--- a/eth/protocols/sstorage/sync_test.go
+++ b/eth/protocols/sstorage/sync_test.go
@@ -453,13 +453,14 @@ func verifyKVs(stateDB *state.StateDB, data map[common.Address]map[uint64][]byte
 		}
 		for idx, val := range shards {
 			_, meta, err := core.GetSstorageMetadata(stateDB, contract, idx)
-			if _, ok := destroyedList[idx]; ok {
-				val = make([]byte, shardData.MaxKvSize())
-			}
 			if err != nil {
 				t.Fatalf("get MetaHash data fail with err: %s.", err.Error())
 			}
 			sval, ok, err := shardData.TryRead(idx, len(val), common.BytesToHash(meta.HashInMeta))
+			if _, ok := destroyedList[idx]; ok {
+				val = make([]byte, shardData.MaxKvSize())
+				sval, ok, err = shardData.TryReadEncoded(idx, len(val))
+			}
 			if err != nil {
 				t.Fatalf("TryRead sstorage Data fail. err: %s", err.Error())
 			}
@@ -846,7 +847,7 @@ func TestSyncWithNoResponse(t *testing.T) {
 		}
 	)
 
-	shards, files := createSstorage(contract, []uint64{0}, sstorage.CHUNK_SIZE_BITS, kvEntries)
+	shards, files := createSstorage(contract, []uint64{0}, sstorage.CHUNK_SIZE_BITS, kvEntriesBits)
 	if shards == nil {
 		t.Fatalf("createSstorage failed")
 	}

--- a/eth/protocols/sstorage/sync_test.go
+++ b/eth/protocols/sstorage/sync_test.go
@@ -36,12 +36,13 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/sstorage"
 	"github.com/holiman/uint256"
-	"golang.org/x/crypto/sha3"
 )
 
 var (
-	contract  = common.HexToAddress("0x0000000000000000000000000000000003330001")
-	kvEntries = uint64(512)
+	miner         = common.HexToAddress("0x0000000000000000000000000000000000000001")
+	contract      = common.HexToAddress("0x0000000000000000000000000000000003330001")
+	kvEntriesBits = uint64(4)
+	kvEntries     = uint64(1) << 4
 )
 
 type (
@@ -245,7 +246,7 @@ func defaultKVRangeRequestHandler(t *testPeer, id uint64, contract common.Addres
 	if vals == nil {
 		t.test.Error("CreateKVRequestResponse fail: vals is nul.")
 	}
-	if err := t.remote.OnKVRange(t, id, common.Address{}, vals); err != nil {
+	if err := t.remote.OnKVRange(t, id, miner, vals); err != nil {
 		t.test.Errorf("Remote side rejected our delivery: %v", err)
 		t.term()
 		return err
@@ -260,7 +261,7 @@ func defaultKVHealRequestHandler(t *testPeer, id uint64, contract common.Address
 	if vals == nil {
 		t.test.Error("CreateKVRequestResponse fail: vals is nul.")
 	}
-	if err := t.remote.OnKVs(t, id, common.Address{}, vals); err != nil {
+	if err := t.remote.OnKVs(t, id, miner, vals); err != nil {
 		t.test.Errorf("Remote side rejected our delivery: %v", err)
 		t.term()
 		return err
@@ -287,7 +288,7 @@ func createKVRequestResponse(t *testPeer, id uint64, stateDB *state.StateDB, con
 			if err != nil {
 				return nil
 			}
-			bs, _, _ := sm.EncodeKV(idx, data, common.BytesToHash(meta.HashInMeta), common.Address{})
+			bs, _, _ := sm.EncodeKV(idx, data, common.BytesToHash(meta.HashInMeta), miner)
 			if uint64(len(bs)) > meta.KVSize {
 				values = append(values, &core.KV{Idx: idx, Data: bs[:meta.KVSize]})
 			} else {
@@ -302,7 +303,7 @@ func createKVRequestResponse(t *testPeer, id uint64, stateDB *state.StateDB, con
 
 // emptyRequestKVRangeFn is a rejects AccountRangeRequests
 func emptyRequestKVRangeFn(t *testPeer, id uint64, contract common.Address, shardId uint64, kvList []uint64) error {
-	t.remote.OnKVRange(t, id, common.Address{}, nil)
+	t.remote.OnKVRange(t, id, miner, nil)
 	return nil
 }
 
@@ -340,7 +341,7 @@ func checkStall(t *testing.T, term func()) chan struct{} {
 	testDone := make(chan struct{})
 	go func() {
 		select {
-		case <-time.After(2 * time.Second):
+		case <-time.After(20 * time.Second):
 			t.Log("Sync stalled")
 			term()
 		case <-testDone:
@@ -373,13 +374,7 @@ func getSlotHash(slotIdx uint64, key common.Hash) common.Hash {
 	slotdata := slot[:]
 	data := append(keydata, slotdata...)
 
-	hasher := sha3.NewLegacyKeccak256().(crypto.KeccakState)
-	hasher.Write(data)
-
-	hashRes := common.Hash{}
-	hasher.Read(hashRes[:])
-
-	return hashRes
+	return crypto.Keccak256Hash(data)
 }
 
 // makeKVStorage generate a range of storage Data and its metadata
@@ -414,10 +409,12 @@ func makeKVStorage(stateDB *state.StateDB, contract common.Address, shards []uin
 	return shardData, shardList
 }
 
-func createSstorage(contract common.Address, shardIdxList []uint64, kvSize,
-	kvEntries, filePerShard uint64, miner common.Address) (map[common.Address][]uint64, []string) {
-	sm := sstorage.NewShardManager(contract, kvSize, kvEntries)
+func createSstorage(contract common.Address, shardIdxList []uint64, kvSizeBits,
+	kvEntriesBits, filePerShard uint64) (map[common.Address][]uint64, []string) {
+	sm := sstorage.NewShardManager(contract, kvSizeBits, kvEntriesBits)
 	sstorage.ContractToShardManager[contract] = sm
+	kvSize := uint64(1) << kvSizeBits
+	kvEntries := uint64(1) << kvEntriesBits
 
 	files := make([]string, 0)
 	for _, shardIdx := range shardIdxList {
@@ -428,8 +425,7 @@ func createSstorage(contract common.Address, shardIdxList []uint64, kvSize,
 			files = append(files, fileName)
 			chunkPerfile := kvEntries * kvSize / sstorage.CHUNK_SIZE / filePerShard
 			startChunkId := fileId * chunkPerfile
-			endChunkId := (fileId + 1) * chunkPerfile
-			_, err := sstorage.Create(fileName, startChunkId, endChunkId, 0, kvSize, sstorage.ENCODE_KECCAK_256, miner)
+			_, err := sstorage.Create(fileName, startChunkId, chunkPerfile, 0, kvSize, sstorage.ENCODE_ETHASH, miner)
 			if err != nil {
 				log.Crit("open failed", "error", err)
 			}
@@ -468,7 +464,18 @@ func verifyKVs(stateDB *state.StateDB, data map[common.Address]map[uint64][]byte
 				t.Fatalf("TryRead sstorage Data fail. err: %s", err.Error())
 			}
 			if !ok {
-				t.Fatalf("TryRead sstroage Data fail. err: %s", "shard Idx not support")
+				t.Fatalf("TryRead sstroage Data fail. err: %s, index %d", "shard Idx not support", idx)
+			}
+
+			if _, ok := destroyedList[idx]; ok {
+				val = make([]byte, sstorage.CHUNK_SIZE)
+				sval, ok, err = shardData.TryReadChunk(idx, common.BytesToHash(make([]byte, 24)))
+				if err != nil {
+					t.Fatalf("TryReadChunk fail. err: %s", err.Error())
+				}
+				if !ok {
+					t.Fatalf("TryReadChunk fail. err: %s", "shard Idx not support")
+				}
 			}
 
 			if !bytes.Equal(val, sval) {
@@ -625,7 +632,7 @@ func checkTasksWithBaskTasks(baseTasks, tasks []*kvTask) error {
 
 // TestReadWrite tests a basic sstorage read/wrtie
 func TestReadWrite(t *testing.T) {
-	shards, files := createSstorage(contract, []uint64{0}, sstorage.CHUNK_SIZE, kvEntries, 1, common.Address{})
+	shards, files := createSstorage(contract, []uint64{0}, sstorage.CHUNK_SIZE_BITS, kvEntriesBits, 1)
 	if shards == nil {
 		t.Fatalf("createSstorage failed")
 	}
@@ -664,7 +671,7 @@ func TestSync(t *testing.T) {
 		}
 	)
 
-	shards, files := createSstorage(contract, []uint64{0}, sstorage.CHUNK_SIZE, kvEntries, 1, common.Address{})
+	shards, files := createSstorage(contract, []uint64{0}, sstorage.CHUNK_SIZE_BITS, kvEntriesBits, 1)
 	if shards == nil {
 		t.Fatalf("createSstorage failed")
 	}
@@ -698,7 +705,6 @@ func TestMultiSubTasksSync(t *testing.T) {
 	var (
 		once          sync.Once
 		cancel        = make(chan struct{})
-		entries       = uint64(1024)
 		destroyedList = make(map[uint64]struct{})
 		stateDB, _    = state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
 		term          = func() {
@@ -708,7 +714,7 @@ func TestMultiSubTasksSync(t *testing.T) {
 		}
 	)
 
-	shards, files := createSstorage(contract, []uint64{0}, sstorage.CHUNK_SIZE, entries, 1, common.Address{})
+	shards, files := createSstorage(contract, []uint64{0}, sstorage.CHUNK_SIZE_BITS, kvEntriesBits, 1)
 	if shards == nil {
 		t.Fatalf("createSstorage failed")
 	}
@@ -727,8 +733,8 @@ func TestMultiSubTasksSync(t *testing.T) {
 		return source
 	}
 
-	data, _ := makeKVStorage(stateDB, contract, []uint64{0}, entries)
-	syncer := setupSyncer(shards, stateDB, entries, mkSource("source", shards, data))
+	data, _ := makeKVStorage(stateDB, contract, []uint64{0}, kvEntries)
+	syncer := setupSyncer(shards, stateDB, kvEntries, mkSource("source", shards, data))
 	done := checkStall(t, term)
 	if err := syncer.Sync(cancel); err != nil {
 		t.Fatalf("sync failed: %v", err)
@@ -751,7 +757,7 @@ func TestMultiSync(t *testing.T) {
 		}
 	)
 
-	shards, files := createSstorage(contract, []uint64{0, 1, 2, 3, 4}, sstorage.CHUNK_SIZE, kvEntries, 1, common.Address{})
+	shards, files := createSstorage(contract, []uint64{0, 1, 2}, sstorage.CHUNK_SIZE_BITS, kvEntriesBits, 1)
 	if shards == nil {
 		t.Fatalf("createSstorage failed")
 	}
@@ -772,14 +778,14 @@ func TestMultiSync(t *testing.T) {
 
 	peers := make([]*testPeer, 0)
 	dataList := make([]map[common.Address]map[uint64][]byte, 0)
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 3; i++ {
 		data, shards := makeKVStorage(stateDB, contract, []uint64{uint64(i)}, kvEntries)
 		dataList = append(dataList, data)
 		peer := mkSource(fmt.Sprintf("source_%d", i), shards, data)
 		peers = append(peers, peer)
 	}
 
-	syncer := setupSyncer(shards, stateDB, kvEntries*5, peers...)
+	syncer := setupSyncer(shards, stateDB, kvEntries*3, peers...)
 	done := checkStall(t, term)
 	if err := syncer.Sync(cancel); err != nil {
 		t.Fatalf("sync failed: %v", err)
@@ -804,7 +810,7 @@ func TestSyncWithEmptyResponse(t *testing.T) {
 		}
 	)
 
-	shards, files := createSstorage(contract, []uint64{0}, sstorage.CHUNK_SIZE, kvEntries, 1, common.Address{})
+	shards, files := createSstorage(contract, []uint64{0}, sstorage.CHUNK_SIZE_BITS, kvEntriesBits, 1)
 	if shards == nil {
 		t.Fatalf("createSstorage failed")
 	}
@@ -851,7 +857,7 @@ func TestSyncWithNoResponse(t *testing.T) {
 		}
 	)
 
-	shards, files := createSstorage(contract, []uint64{0}, sstorage.CHUNK_SIZE, kvEntries, 1, common.Address{})
+	shards, files := createSstorage(contract, []uint64{0}, sstorage.CHUNK_SIZE, kvEntries, 1)
 	if shards == nil {
 		t.Fatalf("createSstorage failed")
 	}
@@ -896,10 +902,10 @@ func TestSyncWithFewerResult(t *testing.T) {
 				close(cancel)
 			})
 		}
-		reduce = rand.Uint64()%(kvEntries/2) - 1
+		reduce = rand.Uint64() % (kvEntries / 2)
 	)
 
-	shards, files := createSstorage(contract, []uint64{0}, sstorage.CHUNK_SIZE, kvEntries, 1, common.Address{})
+	shards, files := createSstorage(contract, []uint64{0}, sstorage.CHUNK_SIZE_BITS, kvEntriesBits, 1)
 	if shards == nil {
 		t.Fatalf("createSstorage failed")
 	}
@@ -941,7 +947,7 @@ func TestSyncMismatchWithMeta(t *testing.T) {
 		}
 	)
 
-	shards, files := createSstorage(contract, []uint64{0}, sstorage.CHUNK_SIZE, kvEntries, 1, common.Address{})
+	shards, files := createSstorage(contract, []uint64{0}, sstorage.CHUNK_SIZE_BITS, kvEntriesBits, 1)
 	if shards == nil {
 		t.Fatalf("createSstorage failed")
 	}
@@ -985,7 +991,7 @@ func TestMultiSyncWithDataOverlay(t *testing.T) {
 		}
 	)
 
-	_, files := createSstorage(contract, []uint64{0, 1, 2, 3}, sstorage.CHUNK_SIZE, kvEntries, 1, common.Address{})
+	_, files := createSstorage(contract, []uint64{0, 1, 2, 3}, sstorage.CHUNK_SIZE_BITS, kvEntriesBits, 1)
 
 	defer func(files []string) {
 		for _, file := range files {
@@ -1006,8 +1012,6 @@ func TestMultiSyncWithDataOverlay(t *testing.T) {
 	peer0 := mkSource("source_0", shards, data)
 	data, shards = makeKVStorage(nil, contract, []uint64{2, 3}, kvEntries)
 	peer1 := mkSource("source_1", shards, data)
-	/*	data, shards = makeKVStorage(nil, contract, []uint64{2, 3}, kvEntries)
-		peer2 := mkSource("source_2", shards, data)*/
 
 	syncer := setupSyncer(localShards, stateDB, kvEntries*4, peer0, peer1)
 	done := checkStall(t, term)
@@ -1032,7 +1036,7 @@ func TestMultiSyncWithDataOverlayWithDestroyed(t *testing.T) {
 	)
 
 	requestTimeoutInMillisecond = 50 * time.Millisecond // Millisecond
-	_, files := createSstorage(contract, []uint64{0, 1, 2}, sstorage.CHUNK_SIZE, kvEntries, 1, common.Address{})
+	_, files := createSstorage(contract, []uint64{0, 1, 2}, sstorage.CHUNK_SIZE_BITS, kvEntriesBits, 1)
 
 	defer func(files []string) {
 		for _, file := range files {
@@ -1079,7 +1083,7 @@ func TestAddPeerDuringSyncing(t *testing.T) {
 	)
 
 	requestTimeoutInMillisecond = 50 * time.Millisecond // Millisecond
-	_, files := createSstorage(contract, []uint64{0, 1, 2}, sstorage.CHUNK_SIZE, kvEntries, 1, common.Address{})
+	_, files := createSstorage(contract, []uint64{0, 1, 2}, sstorage.CHUNK_SIZE_BITS, kvEntriesBits, 1)
 
 	defer func(files []string) {
 		for _, file := range files {
@@ -1123,10 +1127,9 @@ func TestAddPeerDuringSyncing(t *testing.T) {
 func TestSaveAndLoadSyncStatus(t *testing.T) {
 	var (
 		stateDB, _  = state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
-		entries     = kvEntries * 10
-		lastKvIndex = entries*3 - kvEntries - 9
+		lastKvIndex = kvEntries*3 - kvEntriesBits - 1
 	)
-	shards, files := createSstorage(contract, []uint64{0, 1, 2}, sstorage.CHUNK_SIZE, kvEntries, 1, common.Address{})
+	shards, files := createSstorage(contract, []uint64{0, 1, 2}, sstorage.CHUNK_SIZE_BITS, kvEntriesBits, 1)
 	if shards == nil {
 		t.Fatalf("createSstorage failed")
 	}
@@ -1138,10 +1141,10 @@ func TestSaveAndLoadSyncStatus(t *testing.T) {
 	}(files)
 
 	syncer := setupSyncer(shards, stateDB, kvEntries)
-	task0 := createKvTask(contract, entries, 0, lastKvIndex, 20)
+	task0 := createKvTask(contract, kvEntries, 0, lastKvIndex, 8)
 	task0.KvSubTasks = make([]*kvSubTask, 0)
-	task1 := createKvTask(contract, entries, 1, lastKvIndex, 4)
-	task2 := createKvTask(contract, entries, 2, lastKvIndex, 0)
+	task1 := createKvTask(contract, kvEntries, 1, lastKvIndex, 4)
+	task2 := createKvTask(contract, kvEntries, 2, lastKvIndex, 0)
 
 	tasks := []*kvTask{task0, task1, task2}
 	syncer.tasks = tasks

--- a/sstorage/data_file.go
+++ b/sstorage/data_file.go
@@ -21,7 +21,8 @@ const (
 	MAGIC   = uint64(0xcf20bd770c22b2e1)
 	VERSION = uint64(1)
 
-	CHUNK_SIZE = uint64(4096)
+	CHUNK_SIZE      = uint64(4096)
+	CHUNK_SIZE_BITS = uint64(12)
 )
 
 // A DataFile represents a local file for a consective chunks

--- a/sstorage/shard_manager.go
+++ b/sstorage/shard_manager.go
@@ -9,27 +9,53 @@ import (
 type ShardManager struct {
 	shardMap        map[uint64]*DataShard
 	contractAddress common.Address
+	kvSizeBits      uint64
 	kvSize          uint64
+	chunksPerKvBits uint64
 	chunksPerKv     uint64
+	kvEntriesBits   uint64
 	kvEntries       uint64
 }
 
-func NewShardManager(contractAddress common.Address, kvSize uint64, kvEntries uint64) *ShardManager {
+func NewShardManager(contractAddress common.Address, kvSizeBits uint64, kvEntriesBits uint64) *ShardManager {
 	return &ShardManager{
 		shardMap:        make(map[uint64]*DataShard),
 		contractAddress: contractAddress,
-		kvSize:          kvSize,
-		chunksPerKv:     kvSize / CHUNK_SIZE,
-		kvEntries:       kvEntries,
+		kvSizeBits:      kvSizeBits,
+		kvSize:          1 << kvSizeBits,
+		kvEntriesBits:   kvEntriesBits,
+		kvEntries:       1 << kvEntriesBits,
+		chunksPerKvBits: kvSizeBits - CHUNK_SIZE_BITS,
+		chunksPerKv:     1 << (kvSizeBits - CHUNK_SIZE_BITS),
 	}
+}
+
+func (sm *ShardManager) ShardMap() map[uint64]*DataShard {
+	return sm.shardMap
+}
+
+func (sm *ShardManager) ChunksPerKv() uint64 {
+	return sm.chunksPerKv
+}
+
+func (sm *ShardManager) ChunksPerKvBits() uint64 {
+	return sm.chunksPerKvBits
 }
 
 func (sm *ShardManager) KvEntries() uint64 {
 	return sm.kvEntries
 }
 
+func (sm *ShardManager) KvEntriesBits() uint64 {
+	return sm.kvEntriesBits
+}
+
 func (sm *ShardManager) MaxKvSize() uint64 {
 	return sm.kvSize
+}
+
+func (sm *ShardManager) MaxKvSizeBits() uint64 {
+	return sm.kvSizeBits
 }
 
 func (sm *ShardManager) AddDataShard(shardIdx uint64) error {


### PR DESCRIPTION
- use kvSizeBits/kvEntrieBits instead of kvSize/kvEntries to init shard manager
- change AddDataFileFromConfig format from --sstorage.file=4k,<filename> to --sstorage.file=<filename>
- fix test cases